### PR TITLE
Should skip token handler be respecting ensure stable ordering false

### DIFF
--- a/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
+++ b/src/Microsoft.AspNet.OData.Shared/Query/DefaultSkipTokenHandler.cs
@@ -180,10 +180,13 @@ namespace Microsoft.AspNet.OData.Query
 
             if (queryOptions != null)
             {
-                OrderByQueryOption orderBy = queryOptions.GenerateStableOrder();
-                if (orderBy != null)
+                if (querySettings.EnsureStableOrdering)
                 {
-                    orderByNodes = orderBy.OrderByNodes;
+                    OrderByQueryOption orderBy = queryOptions.GenerateStableOrder();
+                    if (orderBy != null)
+                    {
+                        orderByNodes = orderBy.OrderByNodes;
+                    }
                 }
             }
 

--- a/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
+++ b/src/Microsoft.AspNetCore.OData/Microsoft.AspNetCore.OData.csproj
@@ -14,9 +14,9 @@
   <Import Project="..\Microsoft.AspNet.OData.Shared\Microsoft.AspNet.OData.Shared.projitems" Label="Shared" />
 
   <ItemGroup>
-    <PackageReference Include="Desktop.Analyzers" Version="1.1.0" />
+    <!--<PackageReference Include="Desktop.Analyzers" Version="1.1.0" />-->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" />
+    <!--<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="1.1.0" />-->
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Microsoft.OData.Core" Version="7.6.1" />
     <PackageReference Include="Microsoft.OData.Edm" Version="7.6.1" />
@@ -31,7 +31,7 @@
     <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />
+    <!--<PackageReference Include="System.Security.Cryptography.Hashing.Algorithms.Analyzers" Version="1.1.0" />-->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When implementing a custom SkipTokenHandler to make a custom link, you may know the source is ordered in a particular way, and have set EnsureStableOrdering to be false.

Currently, DefaultSkipTokenHandler will reorder the source, even if EnsureStableOrdering is set to false.